### PR TITLE
make defaultOpen prop optional

### DIFF
--- a/packages/terracotta/src/states/create-disclosure-state.ts
+++ b/packages/terracotta/src/states/create-disclosure-state.ts
@@ -17,7 +17,7 @@ export interface DisclosureStateControlledOptions {
   onOpen?: () => void;
 }
 export interface DisclosureStateUncontrolledOptions {
-  defaultOpen: boolean;
+  defaultOpen?: boolean;
   disabled?: boolean;
   onChange?: (state: boolean) => void;
   onClose?: () => void;


### PR DESCRIPTION
in headless UI, `defaultOpen` is an optional Prop on Disclosure and defaults to `false`. in terracotta, this prop is present also in other components, e.g. Popover, and it's a required prop. i'm not sure what the motivation for including it in other components is, but either way i think it's reasonable for this prop to have a default and default to `false`.